### PR TITLE
Increase minimum version of 'exchange_calendars'

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -22,7 +22,7 @@ python_requires = >=3
 install_requires = 
     yfinance >= 0.2.36
     pandas >=1.5, <2.1  # Pandas 2.1 has datetime bug, see Github issue #55487
-    exchange_calendars >= 4.2.5
+    exchange_calendars >= 4.5.3
     scipy >= 1.6.3
     click
 


### PR DESCRIPTION
Newer releases of `exchange_calendars` have important market calendar updates.

Likely to fix #51 