### PR TITLE
Fix div & split propagate ; Improve verify ; API tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Persistent cache stored in your user cache folder:
 - Linux = /home/\<USER\>/.cache/py-yfinance-cache
 - MacOS = /Users/\<USER\>/Library/Caches/py-yfinance-cache
 
+## Install
+
+Available via PIP: `pip install yfinance_cache`
+
 ## Interface
 
 Interaction almost identical to yfinance, listed is attributes with auto-update:
@@ -108,12 +112,13 @@ You can inspect this schedule in new function `dat.get_release_dates()`.
 ## Verifying cache
 
 Cached prices can be compared against latest Yahoo Finance data, and correct differences:
+
 ```python
 # Verify prices of one ticker symbol
 msft.verify_cached_prices(
 	rtol=0.0001,  # relative tolerance for differences
 	vol_rtol=0.005,  # relative tolerance specifically for Volume
-	correct=False,  # delete incorrect cached data?
+	correct=[False|'one'|'all'],  # delete incorrect cached data? 'one' = stop after correcting first incorrect prices table ; 'all' = correct all tickers & intervals
 	discard_old=False,  # if cached data too old to check (e.g. 30m), assume incorrect and delete?
 	quiet=True,  # enable to print nothing, disable to print summary detail of why cached data wrong
 	debug=False,  # enable even more detail for debugging 
@@ -121,19 +126,30 @@ msft.verify_cached_prices(
 
 # Verify prices of entire cache, ticker symbols processed alphabetically. Recommend using `requests_cache` session.
 yfc.verify_cached_tickers_prices(
-	session=None,  # recommend you provide a requests_cache here
+	session=None,  # recommend you provide a requests_cache here if debugging
 	rtol=0.0001,
 	vol_rtol=0.005,
-	correct=False,
+	correct=[False|'one'|'all'],
 	halt_on_fail=True,  # stop verifying on first fail
 	resume_from_tkr=None,  # in case you aborted verification, can jump ahead to this ticker symbol. Append '+1' to start AFTER the ticker
 	debug_tkr=None,  # only verify this ticker symbol
 	debug_interval=None)
 ```
 
-With latest version the only genuine differences you should see are tiny Volume differences (~0.5%). Seems Yahoo is still adjusting Volume over 24 hours after that day ended, e.g. updating Monday Volume on Wednesday.
+These return `False` if difference detected else `True`, regardless of if difference was corrected.
 
-If you see big differences in the OHLC price of recent intervals (last few days), probably Yahoo is wrong! Since fetching that price data on day / day after, Yahoo has messed up their data - at least this is my experience. Cross-check against TradingView or stock exchange website.
+- to scan for first data mismatch but not correct: `yfc.verify_cached_tickers_prices()`. 
+
+- to fix all data issues: `yfc.verify_cached_tickers_prices(correct='all', halt_on_fail=False)`
+
+I hope latest version 0.6.2 fixed the last bugs in applying new dividend-adjustments and splits to cached prices (`Adj Close` etc).
+Only genuine differences in not-adjusted prices are Volume differences (~0.5%) - 
+Yahoo sometimes changes Volume over 24 hours after that day ended e.g. updating Monday Volume on Wednesday, 
+sometimes weeks later!
+
+If you see big differences in the OHLC price of recent intervals (last few days), probably Yahoo is wrong.
+Since fetching that price data on day / day after, Yahoo has messed up their data - at least this is my experience.
+Cross-check against TradingView or stock exchange website.
 
 ## Performance
 
@@ -145,11 +161,6 @@ For each ticker, YFC basically performs 2 tasks:
 
 Throughput on 1 thread decent CPU: task 1 @ ~60/sec, task 2 @ ~5/sec.
 
-## Installation
-
-Available on PIP: `pip install yfinance_cache`
-
 ## Limitations
 
-- only price data is checked if refresh needed
 - intraday pre/post price data not available

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,6 +10,7 @@ import json, pickle
 from time import sleep
 from datetime import datetime, date, time, timedelta
 from zoneinfo import ZoneInfo
+import pandas as pd
 
 from pprint import pprint
 
@@ -66,7 +67,7 @@ class Test_Yfc_Cache(unittest.TestCase):
     def test_cache_store_expiry(self):
         value = 123
 
-        dt = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         exp = dt + timedelta(seconds=1)
 
         yfcm.StoreCacheDatum(self.ticker, self.objName, value, expiry=exp)
@@ -118,7 +119,7 @@ class Test_Yfc_Cache(unittest.TestCase):
         var_grp = "annuals"
         value = 123
 
-        dt = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         exp = dt + timedelta(seconds=1)
 
         yfcm.StoreCachePackedDatum(self.ticker, var, value, expiry=exp)
@@ -147,7 +148,7 @@ class Test_Yfc_Cache(unittest.TestCase):
         json_values.append(int(1))
         json_values.append(float(1))
         json_values.append([1, 3])
-        json_values.append(datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")))
+        json_values.append(pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC")))
         json_values.append(timedelta(seconds=2.01))
 
         pkl_values = []
@@ -194,7 +195,7 @@ class Test_Yfc_Cache(unittest.TestCase):
         key = "k1"
         value = 123
         md = {key:value}
-        exp = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")) + timedelta(hours=1)
+        exp = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC")) + timedelta(hours=1)
 
         yfcm.StoreCacheDatum(self.ticker, self.objName, value, expiry=exp, metadata=md)
         obj,mdc = yfcm.ReadCacheDatum(self.ticker, self.objName, return_metadata_too=True)

--- a/tests/test_price_data_aging_1w.py
+++ b/tests/test_price_data_aging_1w.py
@@ -51,7 +51,7 @@ class Test_PriceDataAging_1W(unittest.TestCase):
         dts = []
         answers = []
         week_start_day = date(2022, 2, 7)
-        answer = datetime.combine(week_start_day + 7*self.td1d, self.market_open, self.market_tz) + self.td4h
+        answer = datetime.combine(week_start_day + 7*self.td1d, self.market_open, self.market_tz) + self.td4h+self.td1d
         for d in range(7, 12):
             day = date(2022, 2,d)
             dt = datetime.combine(day, time(14, 30), self.market_tz)
@@ -59,7 +59,7 @@ class Test_PriceDataAging_1W(unittest.TestCase):
             answers.append(answer+lag)
 
         week_start_day = date(2022, 2, 14)
-        answer = datetime.combine(week_start_day + 7*self.td1d, self.market_open, self.market_tz) + self.td4h + self.td1d  # Monday holiday
+        answer = datetime.combine(week_start_day + 7*self.td1d, self.market_open, self.market_tz) + self.td4h+self.td1d + self.td1d  # Monday holiday
         for d in range(14, 19):
             day = date(2022, 2,d)
             dt = datetime.combine(day, time(14, 30), self.market_tz)
@@ -125,7 +125,7 @@ class Test_PriceDataAging_1W(unittest.TestCase):
         dts = []
         answers = []
         week_start_day = date(2022, 4, 4)
-        answer = datetime.combine(date(2022, 4, 11), self.nze_market_open_time, tz) + self.td4h
+        answer = datetime.combine(date(2022, 4, 11), self.nze_market_open_time, tz) + self.td4h+self.td1d
         for d in range(4, 9):
             day = date(2022, 4, d)
 
@@ -137,7 +137,7 @@ class Test_PriceDataAging_1W(unittest.TestCase):
             answers.append(answer+lag)
 
         week_start_day = date(2022, 4, 11)
-        answer = datetime.combine(date(2022, 4, 19), time(10), tz) + self.td4h
+        answer = datetime.combine(date(2022, 4, 19), time(10), tz) + self.td4h+self.td1d
         for d in range(11, 16):
             day = date(2022, 4, d)
             
@@ -179,7 +179,7 @@ class Test_PriceDataAging_1W(unittest.TestCase):
         lag = timedelta(0)
         dts = []
         answers = []
-        answer = datetime.combine(date(2022, 5, 9), time(8), tz) + self.td4h
+        answer = datetime.combine(date(2022, 5, 9), time(8), tz) + self.td4h+self.td1d
         for d in range(3, 7):  # 2nd is holiday
             day = date(2022, 5, d)
             dt = datetime.combine(day, time(14, 30), tz)

--- a/tests/test_yfc_backend.py
+++ b/tests/test_yfc_backend.py
@@ -88,7 +88,7 @@ class Test_Yfc_Backend(Test_Base):
         ## Only use high-volume stocks:
         tkr_candidates = ["AZN.L", "ASML.AS", "BHG.JO", "INTC", "MEL.NZ"]
 
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
 
         for tkr in tkr_candidates:
             dat = yfc.Ticker(tkr, session=self.session)

--- a/tests/test_yfc_financials.py
+++ b/tests/test_yfc_financials.py
@@ -283,7 +283,7 @@ class Test_Yfc_Financials(unittest.TestCase):
         self.assertTrue(cal_dts is None or len(cal_dts)==0)
     def _test_tagged_calendar_dates_withRefresh(self):
         # Preset the cache
-        cal = {'Earnings Date': [date(2024, 4, 26), date(2024, 4, 30)], 'FetchDate': datetime.utcnow()}
+        cal = {'Earnings Date': [date(2024, 4, 26), date(2024, 4, 30)], 'FetchDate': pd.Timestamp.utcnow()}
         yfcm.StoreCacheDatum(self.T, "calendar", cal)
 
         cal_dts = self.fin._get_tagged_calendar_dates(refresh=True)

--- a/tests/test_yfc_interface.py
+++ b/tests/test_yfc_interface.py
@@ -85,18 +85,24 @@ class Test_Yfc_Interface(Test_Base):
     def test_history_basics1_usa(self):
         # A fetch of prices, then another fetch of same prices, should return identical
 
-        self.assertFalse(os.path.isdir(os.path.join(self.tempCacheDir.name, self.usa_tkr)))
+        self.assertFalse(os.path.isdir(os.path.join(self.tempCacheDir.name, self.usa_tkr, "history-1d.pkl")))
+
+        week_start = date.today()
+        week_start -= timedelta(days=28)
+        week_start -= timedelta(days=week_start.weekday())
+        td_1d = timedelta(days=1)
+        td_7d = timedelta(days=7)
 
         ## Daily 
-        df1 = self.usa_dat.history(interval="1d", start=date(2022,2,7), end=date(2022,2,15))
+        df1 = self.usa_dat.history(interval="1d", start=week_start, end=week_start+td_7d)
         try:
-            self.assertEqual(df1.shape[0], 6)
+            self.assertGreaterEqual(df1.shape[0], 3)
         except:
             print("df1:")
             print(df1)
             print("")
             raise
-        df2 = self.usa_dat.history(interval="1d", start=date(2022,2,7), end=date(2022,2,15))
+        df2 = self.usa_dat.history(interval="1d", start=week_start, end=week_start+td_7d)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -110,11 +116,11 @@ class Test_Yfc_Interface(Test_Base):
         self.assertTrue((df2.index.time==time(0)).all())
 
         ## Daily with actions
-        df1 = self.usa_dat.history(interval="1d", start=date(2022,2,7), end=date(2022,2,15), actions=True)
+        df1 = self.usa_dat.history(interval="1d", start=week_start, end=week_start+td_7d, actions=True)
         self.assertTrue("Dividends" in df1.columns.values)
         self.assertTrue("Stock Splits" in df1.columns.values)
-        self.assertEqual(df1.shape[0], 6)
-        df2 = self.usa_dat.history(interval="1d", start=date(2022,2,7), end=date(2022,2,15), actions=True)
+        self.assertGreaterEqual(df1.shape[0], 3)
+        df2 = self.usa_dat.history(interval="1d", start=week_start, end=week_start+td_7d, actions=True)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -128,14 +134,14 @@ class Test_Yfc_Interface(Test_Base):
         self.assertTrue((df2.index.time==time(0)).all())
 
         ## Hourly
-        df1 = self.usa_dat.history(interval="1h", start=date(2022,2,7), end=date(2022,2,9))
+        df1 = self.usa_dat.history(interval="1h", start=week_start, end=week_start+td_1d*2)
         try:
-            self.assertEqual(df1.shape[0], 14)
+            self.assertGreaterEqual(df1.shape[0], 7)
         except:
             print("df1:")
             print(df1)
             raise
-        df2 = self.usa_dat.history(interval="1h", start=date(2022,2,7), end=date(2022,2,9))
+        df2 = self.usa_dat.history(interval="1h", start=week_start, end=week_start+td_1d*2)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -147,10 +153,10 @@ class Test_Yfc_Interface(Test_Base):
             print("")
             raise
 
-        ## Weekly 
-        df1 = self.usa_dat.history(interval="1wk", start=date(2022,2,7), end=date(2022,2,19))
+        ## Weekly
+        df1 = self.usa_dat.history(interval="1wk", start=week_start, end=week_start+td_1d*14)
         self.assertEqual(df1.shape[0], 2)
-        df2 = self.usa_dat.history(interval="1wk", start=date(2022,2,7), end=date(2022,2,19))
+        df2 = self.usa_dat.history(interval="1wk", start=week_start, end=week_start+td_1d*14)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -180,12 +186,18 @@ class Test_Yfc_Interface(Test_Base):
     def test_history_basics1_nze(self):
         # A fetch of prices, then another fetch of same prices, should return identical
 
-        self.assertFalse(os.path.isdir(os.path.join(self.tempCacheDir.name, self.nze_tkr)))
+        self.assertFalse(os.path.isdir(os.path.join(self.tempCacheDir.name, self.nze_tkr, "history-1d.pkl")))
+
+        week_start = date.today()
+        week_start -= timedelta(days=28)
+        week_start -= timedelta(days=week_start.weekday())
+        td_1d = timedelta(days=1)
+        td_7d = timedelta(days=7)
 
         ## Daily 
-        df1 = self.nze_dat.history(interval="1d", start=date(2022,2,8), end=date(2022,2,15))
-        self.assertEqual(df1.shape[0], 5)
-        df2 = self.nze_dat.history(interval="1d", start=date(2022,2,8), end=date(2022,2,15))
+        df1 = self.nze_dat.history(interval="1d", start=week_start, end=week_start+td_7d)
+        self.assertGreaterEqual(df1.shape[0], 3)
+        df2 = self.nze_dat.history(interval="1d", start=week_start, end=week_start+td_7d)
         try:
             self.verify_df(df1, df2)
         except:
@@ -199,11 +211,11 @@ class Test_Yfc_Interface(Test_Base):
         self.assertTrue((df2.index.time==time(0)).all())
 
         ## Daily with actions
-        df1 = self.nze_dat.history(interval="1d", start=date(2022,2,8), end=date(2022,2,15), actions=True)
+        df1 = self.nze_dat.history(interval="1d", start=week_start, end=week_start+td_7d, actions=True)
         self.assertTrue("Dividends" in df1.columns.values)
         self.assertTrue("Stock Splits" in df1.columns.values)
-        self.assertEqual(df1.shape[0], 5)
-        df2 = self.nze_dat.history(interval="1d", start=date(2022,2,8), end=date(2022,2,15), actions=True)
+        self.assertGreaterEqual(df1.shape[0], 3)
+        df2 = self.nze_dat.history(interval="1d", start=week_start, end=week_start+td_7d, actions=True)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -216,9 +228,9 @@ class Test_Yfc_Interface(Test_Base):
             raise
 
         ## Hourly
-        df1 = self.nze_dat.history(interval="1h", start=date(2022,2,8), end=date(2022,2,10))
-        self.assertEqual(df1.shape[0], 14)
-        df2 = self.nze_dat.history(interval="1h", start=date(2022,2,8), end=date(2022,2,10))
+        df1 = self.nze_dat.history(interval="1h", start=week_start, end=week_start+td_1d*2)
+        self.assertGreaterEqual(df1.shape[0], 7)
+        df2 = self.nze_dat.history(interval="1h", start=week_start, end=week_start+td_1d*2)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -231,9 +243,9 @@ class Test_Yfc_Interface(Test_Base):
             raise
 
         ## Weekly 
-        df1 = self.nze_dat.history(interval="1wk", start=date(2022,2,7), end=date(2022,2,19))
+        df1 = self.nze_dat.history(interval="1wk", start=week_start, end=week_start+td_7d*2)
         self.assertEqual(df1.shape[0], 2)
-        df2 = self.nze_dat.history(interval="1wk", start=date(2022,2,7), end=date(2022,2,19))
+        df2 = self.nze_dat.history(interval="1wk", start=week_start, end=week_start+td_7d*2)
         try:
             self.assertTrue(df1.equals(df2))
         except:
@@ -401,7 +413,7 @@ class Test_Yfc_Interface(Test_Base):
         tkr_candidates = ["BHG.JO", "INTC", "MEL.NZ"]
         interval = yfcd.Interval.Days1
 
-        dt_now_utc = datetime.utcnow()
+        dt_now_utc = pd.Timestamp.utcnow()
         dt_now = dt_now_utc.replace(tzinfo=ZoneInfo("UTC"))
 
         start_d = dt_now_utc.date() -timedelta(days=7)
@@ -428,7 +440,7 @@ class Test_Yfc_Interface(Test_Base):
         # Test 'Final?' column
         tkr_candidates = ["BHG.JO", "INTC", "MEL.NZ"]
 
-        dt_now_utc = datetime.utcnow()
+        dt_now_utc = pd.Timestamp.utcnow()
         dt_now = dt_now_utc.replace(tzinfo=ZoneInfo("UTC"))
 
         # start_d = dt_now_utc.date() - timedelta(days=7)
@@ -601,7 +613,7 @@ class Test_Yfc_Interface(Test_Base):
         del tkr_candidates[tkr_candidates.index("HLTH")]
         del tkr_candidates[tkr_candidates.index("MEL.NZ")]
 
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         start_dt = dt_now - timedelta(days=7)
         end_dt = dt_now+timedelta(days=1)
         start_d = start_dt.date()
@@ -692,7 +704,7 @@ class Test_Yfc_Interface(Test_Base):
         #
         tkr_candidates = ["BHG.JO"]
         #
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         td_1d = timedelta(days=1)
         for tkr in tkr_candidates:
             dat = yfc.Ticker(tkr, session=None)
@@ -759,7 +771,7 @@ class Test_Yfc_Interface(Test_Base):
         tkr_candidates = self.tkrs
         interval = yfcd.Interval.Days1
         #
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         d_now = dt_now.date()
         for tkr in tkr_candidates:
             dat = yfc.Ticker(tkr, session=None)
@@ -801,7 +813,7 @@ class Test_Yfc_Interface(Test_Base):
         tkr_candidates = self.tkrs
         interval = yfcd.Interval.Week
         #
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         d_now = dt_now.date()
         for tkr in tkr_candidates:
             dat = yfc.Ticker(tkr, session=self.session)
@@ -857,7 +869,7 @@ class Test_Yfc_Interface(Test_Base):
         tz = ZoneInfo(tz_name)
         yfct.SetExchangeTzName(exchange, tz_name)
 
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         # d_now = dt_now.date()
         d_now = dt_now.astimezone(tz).date()
         td_1d = timedelta(days=1)
@@ -914,7 +926,7 @@ class Test_Yfc_Interface(Test_Base):
         exchange = dat.fast_info["exchange"]
         yfct.SetExchangeTzName(exchange, dat.fast_info["timezone"])
 
-        dt_now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        dt_now = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
         if yfct.IsTimestampInActiveSession(exchange, dt_now):
             df = dat.history(start=start_d, end=end_d, interval="1d", keepna=True)
             idx = 2 # 3rd row = 2022-7-6

--- a/yfinance_cache/__init__.py
+++ b/yfinance_cache/__init__.py
@@ -6,6 +6,7 @@ from .yfc_multi import download
 from .yfc_logging import EnableLogging, DisableLogging
 from .yfc_cache_manager import _option_manager as options
 
-from .yfc_upgrade import _init_options
+from .yfc_upgrade import _init_options, _reset_cached_cals
 _init_options()
+_reset_cached_cals()
 

--- a/yfinance_cache/yfc_cache_manager.py
+++ b/yfinance_cache/yfc_cache_manager.py
@@ -2,7 +2,7 @@ import os
 import pickle
 import json
 import appdirs
-from pandas import Timedelta
+import pandas as pd
 
 from datetime import datetime, date, timedelta
 from zoneinfo import ZoneInfo
@@ -175,7 +175,7 @@ def ReadCacheDatum(ticker, objectName, return_metadata_too=False):
         expiry = d["expiry"]   if "expiry"   in d else None
 
         if expiry is not None:
-            dtnow = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+            dtnow = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
             if dtnow >= expiry:
                 if verbose:
                     print("Deleting expired datum '{0}/{1}'".format(ticker, objectName))
@@ -213,7 +213,7 @@ def ReadCachePackedDatum(ticker, objectName, return_metadata_too=False):
         expiry = objData["expiry"]   if "expiry"   in objData else None
 
         if expiry is not None:
-            dtnow = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+            dtnow = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC"))
             if dtnow >= expiry:
                 if verbose:
                     print("Deleting expired packed datum '{0}/{1}'".format(ticker, objectName))
@@ -250,7 +250,7 @@ def StoreCacheDatum(ticker, objectName, datum, expiry=None, metadata=None):
     if expiry is not None:
         if isinstance(expiry, yfcd.Interval):
             # Convert interval to actual datetime
-            expiry = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")) + yfcd.intervalToTimedelta[expiry]
+            expiry = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC")) + yfcd.intervalToTimedelta[expiry]
         if not isinstance(expiry, datetime):
             raise Exception("'expiry' must be datetime or yfcd.Interval")
 
@@ -314,7 +314,7 @@ def StoreCachePackedDatum(ticker, objectName, datum, expiry=None, metadata=None)
     if expiry is not None:
         if isinstance(expiry, yfcd.Interval):
             # Convert interval to actual datetime
-            expiry = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")) + yfcd.intervalToTimedelta[expiry]
+            expiry = pd.Timestamp.utcnow().replace(tzinfo=ZoneInfo("UTC")) + yfcd.intervalToTimedelta[expiry]
         if not isinstance(expiry, datetime):
             raise Exception("'expiry' must be datetime or yfcd.Interval")
         if (metadata is not None) and "Expiry" in metadata.keys():
@@ -452,7 +452,7 @@ class NestedOptions:
     def __setattr__(self, key, value):
         if self.name == 'max_ages':
             # Type-check value
-            Timedelta(value)
+            pd.Timedelta(value)
 
         self.data[key] = value
         global _option_manager

--- a/yfinance_cache/yfc_dat.py
+++ b/yfinance_cache/yfc_dat.py
@@ -13,46 +13,40 @@ yf_min_year = 1950
 class Period(Enum):
     Days1 = 0
     Days5 = 1
-    Week = 2
     Months1 = 10
     Months3 = 11
     Months6 = 12
     Years1 = 20
     Years2 = 21
     Years5 = 22
-    Years10 = 23
     Ytd = 24
     Max = 30
 periodToString = {}
 periodToString[Period.Days1] = "1d"
 periodToString[Period.Days5] = "5d"
-periodToString[Period.Week] = "1wk"
 periodToString[Period.Months1] = "1mo"
 periodToString[Period.Months3] = "3mo"
 periodToString[Period.Months6] = "6mo"
 periodToString[Period.Years1] = "1y"
 periodToString[Period.Years2] = "2y"
 periodToString[Period.Years5] = "5y"
-periodToString[Period.Years10] = "10y"
 periodToString[Period.Ytd] = "ytd"
 periodToString[Period.Max] = "max"
 periodStrToEnum = {v: k for k, v in periodToString.items()}
 periodToTimedelta = {}
 periodToTimedelta[Period.Days1] = timedelta(days=1)
-periodToTimedelta[Period.Days5] = timedelta(days=5)
-periodToTimedelta[Period.Week] = timedelta(days=7)
+periodToTimedelta[Period.Days5] = timedelta(days=7)
 periodToTimedelta[Period.Months1] = relativedelta(months=1)
 periodToTimedelta[Period.Months3] = relativedelta(months=3)
 periodToTimedelta[Period.Months6] = relativedelta(months=6)
 periodToTimedelta[Period.Years1] = relativedelta(years=1)
 periodToTimedelta[Period.Years2] = relativedelta(years=2)
 periodToTimedelta[Period.Years5] = relativedelta(years=5)
-periodToTimedelta[Period.Years10] = relativedelta(years=10)
 
 
+# Months3 = 0
+# Months1 = 2
 class Interval(Enum):
-    Months3 = 0
-    Months1 = 2
     Week = 5
     Days1 = 10
     Hours1 = 20
@@ -74,8 +68,8 @@ intervalToString[Interval.Mins90] = "90m"
 intervalToString[Interval.Hours1] = "1h"
 intervalToString[Interval.Days1] = "1d"
 intervalToString[Interval.Week] = "1wk"
-intervalToString[Interval.Months1] = "1mo"
-intervalToString[Interval.Months3] = "3mo"
+# intervalToString[Interval.Months1] = "1mo"
+# intervalToString[Interval.Months3] = "3mo"
 intervalStrToEnum = {v: k for k, v in intervalToString.items()}
 intervalToTimedelta = {}
 intervalToTimedelta[Interval.Mins1] = timedelta(minutes=1)
@@ -88,8 +82,8 @@ intervalToTimedelta[Interval.Mins90] = timedelta(minutes=90)
 intervalToTimedelta[Interval.Hours1] = timedelta(hours=1)
 intervalToTimedelta[Interval.Days1] = timedelta(days=1)
 intervalToTimedelta[Interval.Week] = timedelta(days=7)
-intervalToTimedelta[Interval.Months1] = relativedelta(months=1)
-intervalToTimedelta[Interval.Months3] = relativedelta(months=3)
+# intervalToTimedelta[Interval.Months1] = relativedelta(months=1)
+# intervalToTimedelta[Interval.Months3] = relativedelta(months=3)
 
 
 exchangeToXcalExchange = {}
@@ -112,6 +106,7 @@ exchangeToXcalExchange["IOB"] = exchangeToXcalExchange["LSE"]
 exchangeToXcalExchange["AMS"] = "XAMS"  # Amsterdam
 exchangeToXcalExchange["ATH"] = "ASEX"  # Athens
 exchangeToXcalExchange["BRU"] = "XBRU"  # Brussels
+exchangeToXcalExchange["BVB"] = "XBSE"  # Bucharest
 exchangeToXcalExchange["CPH"] = "XCSE"  # Copenhagen
 exchangeToXcalExchange["EBS"] = "XSWX"  # Zurich
 exchangeToXcalExchange["FRA"] = "XFRA"  # Frankfurt. Germany also has XETRA but that's part of Frankfurt exchange
@@ -140,6 +135,9 @@ exchangeToXcalExchange["SES"] = "XSES"  # Singapore
 exchangeToXcalExchange["HKG"] = "XHKG"  # Hong Kong
 exchangeToXcalExchange["ASX"] = "ASX"   # Australia
 exchangeToXcalExchange["NZE"] = "XNZE"  # New Zealand
+exchangeToXcalExchange["SAU"] = "XSAU"  # Saudi Arabia
+# FX
+exchangeToXcalExchange["CCY"] = "IEPA"  # ICE Data Services
 
 exchangesWithBreaks = {"HKG"}
 
@@ -165,6 +163,7 @@ exchangeToYfLag["IOB"] = timedelta(minutes=20)
 exchangeToYfLag["AMS"] = timedelta(minutes=15)
 exchangeToYfLag["ATH"] = timedelta(minutes=15)
 exchangeToYfLag["BRU"] = timedelta(minutes=15)
+exchangeToYfLag["BVB"] = timedelta(minutes=15)
 exchangeToYfLag["CPH"] = timedelta(0)
 exchangeToYfLag["EBS"] = timedelta(minutes=30)
 exchangeToYfLag["FRA"] = timedelta(minutes=15)
@@ -193,6 +192,10 @@ exchangeToYfLag["SES"] = timedelta(minutes=20)
 exchangeToYfLag["HKG"] = timedelta(minutes=15)
 exchangeToYfLag["ASX"] = timedelta(minutes=20)
 exchangeToYfLag["NZE"] = timedelta(minutes=20)
+exchangeToYfLag["SAU"] = timedelta(minutes=15)
+# FX:
+exchangeToYfLag["CCY"] = timedelta(0)
+exchangeToYfLag["CCC"] = timedelta(0)
 
 # After-market auctions:
 exchangesWithAuction = set()
@@ -219,8 +222,8 @@ yfMaxFetchRange[Interval.Mins60] = timedelta(days=730)
 yfMaxFetchRange[Interval.Hours1] = timedelta(days=730)
 yfMaxFetchRange[Interval.Days1] = None
 yfMaxFetchRange[Interval.Week] = None
-yfMaxFetchRange[Interval.Months1] = None
-yfMaxFetchRange[Interval.Months3] = None
+# yfMaxFetchRange[Interval.Months1] = None
+# yfMaxFetchRange[Interval.Months3] = None
 
 yfMaxFetchLookback = {}
 yfMaxFetchLookback[Interval.Mins1] = timedelta(days=30)
@@ -233,14 +236,14 @@ yfMaxFetchLookback[Interval.Mins60] = timedelta(days=730)
 yfMaxFetchLookback[Interval.Hours1] = timedelta(days=730)
 yfMaxFetchLookback[Interval.Days1] = None
 yfMaxFetchLookback[Interval.Week] = None
-yfMaxFetchLookback[Interval.Months1] = None
-yfMaxFetchLookback[Interval.Months3] = None
+# yfMaxFetchLookback[Interval.Months1] = None
+# yfMaxFetchLookback[Interval.Months3] = None
 
 listing_date_check_tols = {}
 listing_date_check_tols[Interval.Days1] = timedelta(days=7)
 listing_date_check_tols[Interval.Week] = timedelta(days=14)
-listing_date_check_tols[Interval.Months1] = timedelta(days=35)
-listing_date_check_tols[Interval.Months3] = timedelta(days=35*3)
+# listing_date_check_tols[Interval.Months1] = timedelta(days=35)
+# listing_date_check_tols[Interval.Months3] = timedelta(days=35*3)
 
 
 class Financials(Enum):
@@ -425,7 +428,10 @@ class DateIntervalIndex:
         return np.equal(self.array, other.array)
 
     def equals(self, other):
-        return (self == other).all()
+        e = self == other
+        if isinstance(e, np.ndarray):
+            e = e.all()
+        return e
 
     def __str__(self):
         s = "DateIntervalIndex([ "

--- a/yfinance_cache/yfc_upgrade.py
+++ b/yfinance_cache/yfc_upgrade.py
@@ -25,3 +25,29 @@ def _init_options():
         os.makedirs(yfc_dp)
     with open(state_fp, 'w'):
         pass
+
+def _reset_cached_cals():
+    d = yfcm.GetCacheDirpath()
+    yfc_dp = os.path.join(d, "_YFC_")
+    state_fp = os.path.join(yfc_dp, "have-reset-cals")
+    if os.path.isfile(state_fp):
+        return
+
+    if not os.path.isdir(d):
+        if not os.path.isdir(yfc_dp):
+            os.makedirs(yfc_dp)
+        with open(state_fp, 'w'):
+            pass
+        return
+
+    import shutil
+    dp = yfcm.GetCacheDirpath()
+    for d in os.listdir(dp):
+        if d.startswith("exchange-"):
+            shutil.rmtree(os.path.join(dp, d))
+
+    if not os.path.isdir(yfc_dp):
+        os.makedirs(yfc_dp)
+    with open(state_fp, 'w'):
+        pass
+


### PR DESCRIPTION
Dividends:
- fix split-adjusted divs used to adjust not-split-adjusted prices
  - ensure track de-split status, to ensure caching de-splitted dividends - moved new-div-detection up into `_fetchYfHistory()`
- fix dividend=0 entering div cache
- fix `LastDivAdjustDt` not recording reversals (superseded)

Splits:
- fix `LastSplitAdjustDt` not recording reversals (superseded)
- backport split-repair improvement from yfinance:
  - improve bad-split-repair
  - improved sudden-price-change-detection

Prices verify:
- add mode to correct everything without interaction (`correct=all`)
- fix dividends-verify:
  - ensure fetched YF prices date range covers cached dividends
  - add check for orphan dividends

Add exchanges:
- Saudi
- Bucharest

Add FX & crypto
- requires a custom 24/7 calendar `Simple247xcal`. Removed `sessions_nanos` from my cached calendars because actually is a function. Means deleting cached calendars once on upgrade.

Prices general:
- disable periods `1wk` and `10y`
- disable intervals `1mo` and `3mo`
- complete disabling of week & month intervals in `yfc_time`
- fix prices-concat reordering columns
- disable `volume=0` repair on FX
- multiday interval `Final?` time shifted to next-market-open + 4+24 hours
- fix Python 3.12 DT UTC warning

Debug logging tweaks:
- improve logging of new dividends
- improve logging of correcting `Adj Close` in reverse-adjust
- remove logging of 'processed YF response = ...'