### PR TITLE
Fix yfc_time reusing trimmed exchange schedule.

### DIFF
--- a/yfinance_cache/yfc_logging.py
+++ b/yfinance_cache/yfc_logging.py
@@ -4,25 +4,29 @@ import os
 from . import yfc_cache_manager as yfcm
 
 
-yfc_logging_mode = False
+yfc_logging_mode = None
 
-def EnableLogging():
+def EnableLogging(mode=logging.INFO):
     global yfc_logging_mode
-    yfc_logging_mode = True
+    ok_values = [logging.INFO, logging.DEBUG]
+    if mode not in ok_values:
+        raise Exception('Logging mode must be one of:', ok_values)
+    yfc_logging_mode = mode
 
 def DisableLogging():
     global yfc_logging_mode
-    yfc_logging_mode = False
+    yfc_logging_mode = None
 
 def IsLoggingEnabled():
     global yfc_logging_mode
-    return yfc_logging_mode
+    return yfc_logging_mode is not None
 
 loggers = {}
 def GetLogger(tkr):
     if tkr in loggers:
         return loggers[tkr]
 
+    global yfc_logging_mode
     tkr_dp = os.path.join(yfcm.GetCacheDirpath(), tkr)
     if not os.path.isdir(tkr_dp):
         os.mkdir(tkr_dp)
@@ -35,8 +39,7 @@ def GetLogger(tkr):
     # screen_handler = logging.StreamHandler(stream=sys.stdout)
     # screen_handler.setFormatter(formatter)
     logger = logging.getLogger(tkr)
-    logger.setLevel(logging.INFO)
-    # logger.setLevel(logging.DEBUG)
+    logger.setLevel(yfc_logging_mode)
     logger.addHandler(log_file_handler)
     logger.propagate = False
 

--- a/yfinance_cache/yfc_prices_manager.py
+++ b/yfinance_cache/yfc_prices_manager.py
@@ -2047,7 +2047,7 @@ class PriceHistory:
                         df = df.sort_index()
 
         # Improve tolerance to calendar missing a recent new holiday:
-        if (df is None) or df.empty:
+        if df is None or df.empty:
             return None
 
         n = df.shape[0]
@@ -2320,6 +2320,9 @@ class PriceHistory:
                                 intervals.loc[dt, "interval_close"] = df.index[idx] + self.itd
                     else:
                         raise Exception("Problem with dates returned by Yahoo, see above")
+
+        if df is None or df.empty:
+            return None
 
         df = df.copy()
 

--- a/yfinance_cache/yfc_time.py
+++ b/yfinance_cache/yfc_time.py
@@ -12,6 +12,8 @@ import pandas as pd
 import numpy as np
 import exchange_calendars as xcal
 
+from yfinance_cache import yfc_logging as yfcl
+
 from . import yfc_dat as yfcd
 from . import yfc_cache_manager as yfcm
 from . import yfc_utils as yfcu
@@ -549,8 +551,9 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
     # debug = True
 
     if debug:
-        print("GetExchangeScheduleIntervals()", locals())
-        print("- types: start={} end={}".format(type(start), type(end)))
+        yfc_logger = yfcl.GetLogger("exchange-"+exchange)
+        yfc_logger.debug("GetExchangeScheduleIntervals()")
+        yfc_logger.debug("- " + str(locals()))
 
     dt_now = pd.Timestamp.utcnow()
     tz = ZoneInfo(GetExchangeTzName(exchange))
@@ -577,16 +580,21 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
                 s = s[s.left >= start_dt]
             if len(s) > 0 and isinstance(s.right[0], datetime):
                 s = s[s.right <= end_dt]
-            if debug:
-                print("- returning cached intervals ({}->{} filtered by {}->{})".format(start_d, end_d, start, end))
+
+            if exclude_future and intraday:
+                s = s[s.left <= dt_now]
+                if debug:
+                    yfc_logger.debug("- returning cached intervals ({}->{} filtered by {}->{})".format(start_d, end_d, start, min(end, dt_now)))
+            elif debug:
+                yfc_logger.debug("- returning cached intervals ({}->{} filtered by {}->{})".format(start_d, end_d, start, end))
         return s
 
     if debug:
-        print("- start_d={}, end_d={}".format(start_d, end_d))
+        yfc_logger.debug("- start_d={}, end_d={}".format(start_d, end_d))
 
     week_starts_sunday = (exchange in ["TLV"]) and (not week7days)
     if debug:
-        print("- week_starts_sunday =", week_starts_sunday)
+        yfc_logger.debug(f"- week_starts_sunday = {week_starts_sunday}")
 
     if exchange not in yfcd.exchangeToXcalExchange:
         raise Exception("Need to add mapping of exchange {} to xcal".format(exchange))
@@ -596,7 +604,7 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
     # apply datetime limits.
     intervals = None
     istr = yfcd.intervalToString[interval]
-    if istr.endswith('h') or istr.endswith('m'):
+    if intraday:
         if itd > timedelta(minutes=30):
             align = "-30m"
         else:
@@ -606,8 +614,6 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
             return None
         # Transfer IntervalIndex to DataFrame so can modify
         intervals_df = pd.DataFrame(data={"interval_open": ti.left.tz_convert(tz), "interval_close": ti.right.tz_convert(tz)})
-        if exclude_future:
-            intervals_df = intervals_df[intervals_df["interval_open"] <= dt_now]
         if "auction" in cal.schedule.columns:
             sched = GetExchangeSchedule(exchange, start_d, end_d)
             sched.index = sched.index.date
@@ -695,8 +701,8 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
                 return None
             s = s.copy()
         if debug:
-            print("- sched:")
-            print(s)
+            yfc_logger.debug("- sched:")
+            yfc_logger.debug(s)
         if discardTimes:
             open_days = np.array([dt.to_pydatetime().astimezone(tz).date() for dt in s["open"]])
             intervals = yfcd.DateIntervalIndex.from_arrays(open_days, open_days+td_1d, closed="left")
@@ -729,14 +735,20 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
     if cache_key is not None:
         schedIntervalsCache[cache_key] = intervals
 
+    # Only after caching can we prune future intervals
+    if exclude_future and intraday:
+        intervals = intervals[intervals.left <= dt_now]
+
     if intervals is not None:
         if isinstance(intervals.left[0], datetime):
             intervals = intervals[(intervals.left >= start_dt) & (intervals.right <= end_dt)]
         if len(intervals) == 0:
             intervals = None
 
-    if debug:
-        print(f"GetExchangeScheduleIntervals() returning {type(intervals)} {intervals.left[0]} -> {intervals.right[-1]}")
+    if intervals is not None:
+        yfc_logger.debug(f"GetExchangeScheduleIntervals({istr}) returning interval starts {intervals.left[0]} -> {intervals.left[-1]}")
+    else:
+        yfc_logger.debug(f"GetExchangeScheduleIntervals({istr}) returning None")
     return intervals
 
 


### PR DESCRIPTION
A schedule was being put in the memory cache AFTER trimming future intervals. This was a problem for intraday schedules, because the near-future quickly becomes present & past. So after running for a long time, YFC was claiming Yahoo data didn't map to schedule.

Fixes #51 

Also improved logging slightly: set logging level via `yfcl.EnableLogging()`