### PR TITLE
requires numpy version 1.26.x (< 2.0) and appdirs module fix #65 #64

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -18,13 +18,15 @@ classifiers =
 package_dir =
     = ./
 packages = find:
-python_requires = >=3
+python_requires = >=3.9
 install_requires = 
     yfinance >= 0.2.36
+    numpy >= 1.26 <2.0  # Pandas require 1.x NumPy version
     pandas >=1.5, <2.1  # Pandas 2.1 has datetime bug, see Github issue #55487
     exchange_calendars >= 4.5.5
     scipy >= 1.6.3
     click
+    appdirs
 
 [options.packages.find]
 where = ./

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -21,7 +21,7 @@ packages = find:
 python_requires = >=3.9
 install_requires = 
     yfinance >= 0.2.36
-    numpy >= 1.26 <2.0  # Pandas require 1.x NumPy version
+    numpy >= 1.26 <2.0  # Pandas<2.1 requires Numpy<2, see Github issue #59052
     pandas >=1.5, <2.1  # Pandas 2.1 has datetime bug, see Github issue #55487
     exchange_calendars >= 4.5.5
     scipy >= 1.6.3


### PR DESCRIPTION
yfinance-cache is not compatible with numpy 2.0. 
making sure numpy 1.26 is installed
also requires appdirs and zoneinfo
fix #65 and #64