### PR TITLE
added line return on completed progress bar

### DIFF
--- a/yfinance_cache/yfc_utils.py
+++ b/yfinance_cache/yfc_utils.py
@@ -674,3 +674,6 @@ def display_progress_bar(completed, total):
     bar = "*" * completed_length + " " * (bar_length - completed_length)
     # print(f"\rProgress: |{bar}| {percentage:.0f}% Completed", end='', flush=True)
     print(f"\r[{bar}]  {completed} of {total} completed", end='', flush=True)
+    # add return after the last progress
+    if completed == total:
+        print("\n")


### PR DESCRIPTION
solve the issue where printing after the progress bar show on the same line. see the word "buy" below
```
[************************************************]  12 of 12 completedbuy:
```

after patch:
```
[************************************************]  12 of 12 completed

buy:
```