### PR TITLE
Fix Pandas warnings and unblock Pandas update

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -21,8 +21,8 @@ packages = find:
 python_requires = >=3.9
 install_requires = 
     yfinance >= 0.2.36
-    numpy >= 1.26, <2.0  # Pandas<2.1 requires Numpy<2, see Github issue #59052
-    pandas >=1.5, <2.1  # Pandas 2.1 has datetime bug, see Github issue #55487
+    numpy >= 1.26
+    pandas >= 1.5
     exchange_calendars >= 4.5.5
     scipy >= 1.6.3
     click

--- a/yfinance_cache/yfc_financials_manager.py
+++ b/yfinance_cache/yfc_financials_manager.py
@@ -691,7 +691,7 @@ class FinancialsManager:
                 # Drop dates that occurred just before another
                 edf = edf.sort_index(ascending=True)
                 d = edf.index.to_series().diff()
-                d[0] = pd.Timedelta(999, unit='d')
+                d.iloc[0] = pd.Timedelta(999, unit='d')
                 x_near = np.abs(d) < pd.Timedelta(5, "days")
                 if x_near.any():
                     edf = edf[~x_near]

--- a/yfinance_cache/yfc_ticker.py
+++ b/yfinance_cache/yfc_ticker.py
@@ -725,9 +725,9 @@ class Ticker:
         df = pd.DataFrame(df, columns=['Shares'])
 
         if start_d < df.index[0].date():
-            df.loc[start_dt] = np.nan
+            df.loc[start_dt, 'Shares'] = np.nan
         if (end_d-td_1d) > df.index[-1].date():
-            df.loc[end_dt] = np.nan
+            df.loc[end_dt, 'Shares'] = np.nan
         df = df.sort_index()
 
         df['FetchDate'] = fetch_dt

--- a/yfinance_cache/yfc_time.py
+++ b/yfinance_cache/yfc_time.py
@@ -201,6 +201,8 @@ def GetCalendarViaCache(exchange, start, end=None):
             cal, md = yfcm.ReadCacheDatum(cache_key, "cal", True)
             if xcal.__version__ != md["version"]:
                 cal = None
+            elif 'np version' not in md or md['np version'] != np.__version__:
+                cal = None
 
         # Calculate missing data
         pre_range = None ; post_range = None
@@ -246,7 +248,7 @@ def GetCalendarViaCache(exchange, start, end=None):
         # Write to cache
         calCache[cal_name] = cal
         if pre_range is not None or post_range is not None:
-            yfcm.StoreCacheDatum(cache_key, "cal", cal, metadata={"version": xcal.__version__})
+            yfcm.StoreCacheDatum(cache_key, "cal", cal, metadata={"version": xcal.__version__, 'np version': np.__version__})
 
     return cal
 
@@ -645,7 +647,7 @@ def GetExchangeScheduleIntervals(exchange, interval, start, end, discardTimes=No
             # Implemented by flooring then applying offset calculated from floored market open.
             intervals_grp = intervals_df.groupby(intervals_df["interval_open"].dt.date)
             # 1 - calculate offset
-            res = istr.replace('h', 'H') if istr.endswith('h') else istr.replace('m', 'T')
+            res = 'h' if istr.endswith('h') else istr.replace('m', 'T')
             market_opens = intervals_grp.min()["interval_open"]
             if len(market_opens.dt.time.unique()) == 1:
                 open0 = market_opens.iloc[0]

--- a/yfinance_cache/yfc_upgrade.py
+++ b/yfinance_cache/yfc_upgrade.py
@@ -1,4 +1,6 @@
 import os
+import pickle as pkl
+import pandas as pd
 
 from . import yfc_cache_manager as yfcm
 
@@ -45,6 +47,68 @@ def _reset_cached_cals():
     for d in os.listdir(dp):
         if d.startswith("exchange-"):
             shutil.rmtree(os.path.join(dp, d))
+
+    if not os.path.isdir(yfc_dp):
+        os.makedirs(yfc_dp)
+    with open(state_fp, 'w'):
+        pass
+
+
+def _fix_dt_types_in_divs_splits():
+    d = yfcm.GetCacheDirpath()
+    yfc_dp = os.path.join(d, "_YFC_")
+    state_fp = os.path.join(yfc_dp, "have-fixed-types-in-divs-splits")
+    if os.path.isfile(state_fp):
+        return
+    if not os.path.isdir(d):
+        if not os.path.isdir(yfc_dp):
+            os.makedirs(yfc_dp)
+        with open(state_fp, 'w'):
+            pass
+        return
+
+    dp = yfcm.GetCacheDirpath()
+    for d in os.listdir(dp):
+        if d.startswith("exchange-"):
+            pass
+        else:
+            # dividends
+            divs_fp = os.path.join(dp, d, 'dividends.pkl')
+            if os.path.isfile(divs_fp):
+                with open(divs_fp, 'rb') as F:
+                    data = pkl.load(F)
+                df = data['data']
+                # print(df)
+                c = 'Superseded div FetchDate'
+                if c in df.columns:
+                    # Ensure NaN values are pd.NaT not np.nan
+                    f_na = df[c].isna()    
+                    if f_na.any():
+                        if not pd.api.types.is_datetime64_any_dtype(df[c]):
+                            df.loc[f_na, c] = pd.NaT
+                            df[c] = pd.to_datetime(df[c])
+                            with open(divs_fp, 'wb') as F:
+                                data['data'] = df
+                                pkl.dump(data, F, 4)
+
+            # splits
+            splits_fp = os.path.join(dp, d, 'splits.pkl')
+            if os.path.isfile(splits_fp):
+                with open(splits_fp, 'rb') as F:
+                    data = pkl.load(F)
+                df = data['data']
+                # print(df)
+                c = 'Superseded split FetchDate'
+                if c in df.columns:
+                    # Ensure NaN values are pd.NaT not np.nan
+                    f_na = df[c].isna()    
+                    if f_na.any():
+                        if not pd.api.types.is_datetime64_any_dtype(df[c]):
+                            df.loc[f_na, c] = pd.NaT
+                            df[c] = pd.to_datetime(df[c])
+                            with open(splits_fp, 'wb') as F:
+                                data['data'] = df
+                                pkl.dump(data, F, 4)
 
     if not os.path.isdir(yfc_dp):
         os.makedirs(yfc_dp)


### PR DESCRIPTION
Testing confirms Pandas issue #55487 solved. Means can allow Pandas 2.2+
Fix some Pandas warnings.
Add Numpy version to cached calendars.
Fix datetime types in cached divs & splits.