### PR TITLE
Fix ETF downloading errors

### DIFF
--- a/yfinance_cache/yfc_dat.py
+++ b/yfinance_cache/yfc_dat.py
@@ -90,7 +90,7 @@ exchangeToXcalExchange = {}
 # USA:
 exchangeToXcalExchange["NYQ"] = "XNYS"
 exchangeToXcalExchange["ASE"] = exchangeToXcalExchange["NYQ"]
-exchangeToXcalExchange["PCX"] = exchangeToXcalExchange["NYQ"]  # NYSE Arca
+exchangeToXcalExchange["PCX"] = exchangeToXcalExchange["NYQ"]  # ARCA follows NYSE calendar
 exchangeToXcalExchange["PNK"] = exchangeToXcalExchange["NYQ"]  # OTC pink
 exchangeToXcalExchange["OQX"] = exchangeToXcalExchange["NYQ"]  # OTCQX
 exchangeToXcalExchange["OEM"] = exchangeToXcalExchange["NYQ"]  # OTC EXMKT

--- a/yfinance_cache/yfc_dat.py
+++ b/yfinance_cache/yfc_dat.py
@@ -95,6 +95,9 @@ exchangeToXcalExchange["PNK"] = exchangeToXcalExchange["NYQ"]  # OTC pink
 exchangeToXcalExchange["OQX"] = exchangeToXcalExchange["NYQ"]  # OTCQX
 exchangeToXcalExchange["OEM"] = exchangeToXcalExchange["NYQ"]  # OTC EXMKT
 exchangeToXcalExchange["OQB"] = exchangeToXcalExchange["NYQ"]  # OTCQB
+exchangeToXcalExchange["DJI"] = exchangeToXcalExchange["NYQ"]  # Dow Jones follows NYSE calendar
+exchangeToXcalExchange["SNP"] = exchangeToXcalExchange["NYQ"]  # S&P 500 follows NYSE calendar
+exchangeToXcalExchange["NIM"] = "NASDAQ"  # NASDAQ Index Market follows NASDAQ calendar
 exchangeToXcalExchange["NCM"] = "NASDAQ"
 exchangeToXcalExchange["NGM"] = exchangeToXcalExchange["NCM"]
 exchangeToXcalExchange["NMS"] = exchangeToXcalExchange["NCM"]
@@ -167,11 +170,14 @@ exchangeToYfLag = {}
 exchangeToYfLag["NYQ"] = timedelta(seconds=0)
 exchangeToYfLag["ASE"] = exchangeToYfLag["NYQ"]
 exchangeToYfLag["PCX"] = exchangeToYfLag["NYQ"]
+exchangeToYfLag["DJI"] = exchangeToYfLag["NYQ"]  # Dow Jones has same lag as NYSE
+exchangeToYfLag["SNP"] = exchangeToYfLag["NYQ"]  # S&P 500 has same lag as NYSE
 exchangeToYfLag["PNK"] = timedelta(minutes=15)
 exchangeToYfLag["OQX"] = timedelta(minutes=15)
 exchangeToYfLag["OEM"] = exchangeToYfLag["OQX"]
 exchangeToYfLag["OQB"] = exchangeToYfLag["OQX"]
 exchangeToYfLag["NCM"] = exchangeToYfLag["ASE"]
+exchangeToYfLag["NIM"] = exchangeToYfLag["NCM"]  # NASDAQ Index Market has same lag as NASDAQ
 exchangeToYfLag["NGM"] = exchangeToYfLag["ASE"]
 exchangeToYfLag["NMS"] = exchangeToYfLag["ASE"]
 exchangeToYfLag["BTS"] = exchangeToYfLag["NYQ"]

--- a/yfinance_cache/yfc_dat.py
+++ b/yfinance_cache/yfc_dat.py
@@ -90,14 +90,11 @@ exchangeToXcalExchange = {}
 # USA:
 exchangeToXcalExchange["NYQ"] = "XNYS"
 exchangeToXcalExchange["ASE"] = exchangeToXcalExchange["NYQ"]
-exchangeToXcalExchange["PCX"] = exchangeToXcalExchange["NYQ"]  # ARCA follows NYSE calendar
+exchangeToXcalExchange["PCX"] = exchangeToXcalExchange["NYQ"]  # NYSE Arca
 exchangeToXcalExchange["PNK"] = exchangeToXcalExchange["NYQ"]  # OTC pink
 exchangeToXcalExchange["OQX"] = exchangeToXcalExchange["NYQ"]  # OTCQX
 exchangeToXcalExchange["OEM"] = exchangeToXcalExchange["NYQ"]  # OTC EXMKT
 exchangeToXcalExchange["OQB"] = exchangeToXcalExchange["NYQ"]  # OTCQB
-exchangeToXcalExchange["DJI"] = exchangeToXcalExchange["NYQ"]  # Dow Jones follows NYSE calendar
-exchangeToXcalExchange["SNP"] = exchangeToXcalExchange["NYQ"]  # S&P 500 follows NYSE calendar
-exchangeToXcalExchange["NIM"] = "NASDAQ"  # NASDAQ Index Market follows NASDAQ calendar
 exchangeToXcalExchange["NCM"] = "NASDAQ"
 exchangeToXcalExchange["NGM"] = exchangeToXcalExchange["NCM"]
 exchangeToXcalExchange["NMS"] = exchangeToXcalExchange["NCM"]
@@ -170,14 +167,11 @@ exchangeToYfLag = {}
 exchangeToYfLag["NYQ"] = timedelta(seconds=0)
 exchangeToYfLag["ASE"] = exchangeToYfLag["NYQ"]
 exchangeToYfLag["PCX"] = exchangeToYfLag["NYQ"]
-exchangeToYfLag["DJI"] = exchangeToYfLag["NYQ"]  # Dow Jones has same lag as NYSE
-exchangeToYfLag["SNP"] = exchangeToYfLag["NYQ"]  # S&P 500 has same lag as NYSE
 exchangeToYfLag["PNK"] = timedelta(minutes=15)
 exchangeToYfLag["OQX"] = timedelta(minutes=15)
 exchangeToYfLag["OEM"] = exchangeToYfLag["OQX"]
 exchangeToYfLag["OQB"] = exchangeToYfLag["OQX"]
 exchangeToYfLag["NCM"] = exchangeToYfLag["ASE"]
-exchangeToYfLag["NIM"] = exchangeToYfLag["NCM"]  # NASDAQ Index Market has same lag as NASDAQ
 exchangeToYfLag["NGM"] = exchangeToYfLag["ASE"]
 exchangeToYfLag["NMS"] = exchangeToYfLag["ASE"]
 exchangeToYfLag["BTS"] = exchangeToYfLag["NYQ"]

--- a/yfinance_cache/yfc_multi.py
+++ b/yfinance_cache/yfc_multi.py
@@ -44,7 +44,7 @@ def download(tickers,
         if threads is True:
             threads = multiprocessing.cpu_count()
         if progress:
-            queue = multiprocessing.Manager().Queue()
+            queue = yfcd.get_manager().Queue()
             partial_func = partial(download_one_parallel, queue=queue, 
                                     period=period, interval=interval,
                                     max_age=max_age,

--- a/yfinance_cache/yfc_utils.py
+++ b/yfinance_cache/yfc_utils.py
@@ -63,10 +63,11 @@ def TypeCheckDateEasy(var, varName):
         elif not isinstance(var.tzinfo, ZoneInfo):
             raise TypeError(f"'{varName}' tzinfo must be ZoneInfo not {type(var.tzinfo)}")
 def TypeCheckDateStrict(var, varName):
-    if var is None:
-        return  # Allow None values
-    if not isinstance(var, (date, datetime)):
-        raise TypeError(f"'{varName}' must be date or datetime not {type(var)}")
+    if isinstance(var, pd.Timestamp):
+        # While Pandas missing support for 'zoneinfo' must deny
+        raise TypeError(f"'{varName}' must be date not {type(var)}")
+    if not (isinstance(var, date) and not isinstance(var, datetime)):
+        raise TypeError(f"'{varName}' must be date not {type(var)}")
 def TypeCheckDatetime(var, varName):
     if not isinstance(var, datetime):
         raise TypeError(f"'{varName}' must be datetime not {type(var)}")

--- a/yfinance_cache/yfc_utils.py
+++ b/yfinance_cache/yfc_utils.py
@@ -63,11 +63,10 @@ def TypeCheckDateEasy(var, varName):
         elif not isinstance(var.tzinfo, ZoneInfo):
             raise TypeError(f"'{varName}' tzinfo must be ZoneInfo not {type(var.tzinfo)}")
 def TypeCheckDateStrict(var, varName):
-    if isinstance(var, pd.Timestamp):
-        # While Pandas missing support for 'zoneinfo' must deny
-        raise TypeError(f"'{varName}' must be date not {type(var)}")
-    if not (isinstance(var, date) and not isinstance(var, datetime)):
-        raise TypeError(f"'{varName}' must be date not {type(var)}")
+    if var is None:
+        return  # Allow None values
+    if not isinstance(var, (date, datetime)):
+        raise TypeError(f"'{varName}' must be date or datetime not {type(var)}")
 def TypeCheckDatetime(var, varName):
     if not isinstance(var, datetime):
         raise TypeError(f"'{varName}' must be datetime not {type(var)}")


### PR DESCRIPTION
Running the following code had a chain of errors:

```python
import yfinance_cache as yf

x = yf.download(["XLK", "XLY", "XLP", "TLT"],
            period="10d",
            end=None,
            progress=False,
            threads=False,
            interval="1d",
            rounding=True,
        )

print(x)
```

The first was due to a bug in multiprocessing manager creation (fixed with 8bc070b)

```bash
Traceback (most recent call last):
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_ticker.py", line 105, in history
    yfct.SetExchangeTzName(exchange, tz_name)
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_time.py", line 38, in SetExchangeTzName
    raise Exception(f"Need to add mapping of exchange {exchange} to xcal")
Exception: Need to add mapping of exchange PCX to xcal

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 291, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/test.py", line 3, in <module>
    x = yf.download(["XLK", "XLY", "XLP", "TLT"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_multi.py", line 107, in download
    df = yfc_ticker.Ticker(tkr, session=session).history(**hist_args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_ticker.py", line 108, in history
    raise Exception(f"Need to add mapping of exchange {exchange} to xcal (ticker={self._ticker})")
Exception: Need to add mapping of exchange PCX to xcal (ticker=XLK)
Traceback (most recent call last):
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/test.py", line 1, in <module>
    import yfinance_cache as yf
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/__init__.py", line 3, in <module>
    from .yfc_dat import Period, Interval, AmbiguousComparisonException
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_dat.py", line 289, in <module>
    manager = Manager()
              ^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/context.py", line 57, in Manager
    m.start()
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/managers.py", line 567, in start
    self._address = reader.recv()
                    ^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
          ^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/connection.py", line 430, in _recv_bytes
    buf = self._recv(4)
          ^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/connection.py", line 399, in _recv
    raise EOFError
EOFError
```

The second was due to not handling Nonetypes in `TypeCheckDateStrict` (fixed in 701a4e24):

```bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/.conda/lib/python3.11/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 291, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/test.py", line 3, in <module>
    x = yf.download(["XLK", "XLY", "XLP", "TLT"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_multi.py", line 107, in download
    df = yfc_ticker.Ticker(tkr, session=session).history(**hist_args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_ticker.py", line 238, in history
    self._histories_manager = yfcp.HistoriesManager(self._ticker, exchange, tz_name, lday, self._session, proxy)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_prices_manager.py", line 36, in __init__
    yfcu.TypeCheckDateStrict(listingDay, 'listingDay')
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_utils.py", line 70, in TypeCheckDateStrict
    raise TypeError(f"'{varName}' must be date not {type(var)}")
TypeError: 'listingDay' must be date not <class 'NoneType'>
Warning: Failed to initialize Manager locks: 
Traceback (most recent call last):
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/test.py", line 3, in <module>
    x = yf.download(["XLK", "XLY", "XLP", "TLT"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_multi.py", line 107, in download
    df = yfc_ticker.Ticker(tkr, session=session).history(**hist_args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_ticker.py", line 238, in history
    self._histories_manager = yfcp.HistoriesManager(self._ticker, exchange, tz_name, lday, self._session, proxy)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_prices_manager.py", line 36, in __init__
    yfcu.TypeCheckDateStrict(listingDay, 'listingDay')
  File "/Users/rdecal/src/PERSONAL/yfinance-cache/yfinance_cache/yfc_utils.py", line 70, in TypeCheckDateStrict
    raise TypeError(f"'{varName}' must be date not {type(var)}")
TypeError: 'listingDay' must be date not <class 'NoneType'>
```

These two commits make the test script run correctly. Should fix issue #72 